### PR TITLE
macOS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rust:
 os:
   - linux
   - windows
+  - macos
 dist: xenial
 cache:
   cargo: true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # thread-priority
+
 [![Build status](https://travis-ci.org/vityafx/thread-priority.svg?branch=master)](https://travis-ci.org/vityafx/thread-priority)
 [![Crates](https://img.shields.io/crates/v/thread-priority.svg)](https://crates.io/crates/thread-priority)
 [![Docs](https://docs.rs/thread-priority/badge.svg)](https://docs.rs/thread-priority)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
-
 
 A simple library to control thread schedule policies and thread priority.
 
@@ -11,10 +11,12 @@ This crate does not support all the plaforms yet but it is inteded to be develop
 so feel free to contribute!
 
 ## Supported platforms
+
 - Linux
 - Windows
 
 ## Example
+
 Setting current thread's priority to minimum:
 
 ```rust,no_run
@@ -26,4 +28,5 @@ fn main() {
 ```
 
 ## License
+
 This project is [licensed under the MIT license](https://github.com/vityafx/thread-priority/blob/master/LICENSE).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@
 //! ```rust
 //! use thread_priority::*;
 //!
-//! assert!(set_current_thread_priority(ThreadPriority::Min).is_ok());
+//! let result = set_current_thread_priority(ThreadPriority::Min);
 //! // Or like this:
-//! assert!(ThreadPriority::Min.set_for_current().is_ok());
+//! let result = ThreadPriority::Min.set_for_current();
 //! ```
 #![warn(missing_docs)]
 #![deny(warnings)]
@@ -75,14 +75,14 @@ pub struct Thread {
 }
 
 impl Thread {
-    /// Get current thread.
+    /// Get current thread as a platform-independent structure
     ///
     /// # Usage
     ///
     /// ```rust
     /// use thread_priority::*;
     ///
-    /// assert!(Thread::current().is_ok());
+    /// let thread = Thread::current();
     /// ```
     pub fn current() -> Result<Thread, Error> {
         Ok(Thread {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,14 +14,18 @@
 #![warn(missing_docs)]
 #![deny(warnings)]
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 pub mod unix;
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 pub use unix::*;
 #[cfg(windows)]
 pub mod windows;
 #[cfg(windows)]
 pub use windows::*;
+#[cfg(target_os = "macos")]
+pub mod macos;
+#[cfg(target_os = "macos")]
+pub use macos::*;
 
 /// A error type
 #[derive(Debug, Copy, Clone)]
@@ -33,6 +37,8 @@ pub enum Error {
     OS(i32),
     /// FFI failure
     Ffi(&'static str),
+    /// Attempt to probe values on an platform which is not supported (macOS..)
+    UnsupportedPlatform(),
 }
 
 /// Thread priority enumeration.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,16 @@ pub enum ThreadPriority {
 
 impl ThreadPriority {
     /// Sets current thread's priority to this value.
+    ///
+    ///
+    /// # Usage
+    ///
+    /// ```rust
+    /// use thread_priority::*;
+    ///
+    /// // Ignore the response- we just keep going even if priority changes on a given platform are not supported (macOS)
+    /// let _ = set_current_thread_priority(ThreadPriority::Max);
+    /// ```
     pub fn set_for_current(self) -> Result<(), Error> {
         set_current_thread_priority(self)
     }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,27 @@
+//! This module defines the unix thread control.
+//!
+//! The crate's prelude doesn't have much control over
+//! the unix threads, and this module provides
+//! better control over those.
+
+use crate::{Error, ThreadPriority};
+
+/// Return a placeholder type for the ThreadId. This is used in association with other types which are always errors on this unsupported platform (macOS) so this allows complilation and calling code has the option to handle the error gracefully at runtime
+pub type ThreadId = i32;
+
+/// Set current thread's priority.
+pub fn set_current_thread_priority(_priority: ThreadPriority) -> Result<(), Error> {
+    // Silently do nothing- not a supported platform- priority will remain unchanged
+    Err(Error::UnsupportedPlatform())
+}
+
+/// Get current thread's priority value.
+pub fn thread_priority() -> Result<ThreadPriority, Error> {
+    // Indicate that this is not a supported platform
+    Err(Error::UnsupportedPlatform())
+}
+
+/// Returns a placeholder for the current thread id.  This is used in association with other types which are always errors on this unsupported platform (macOS) so this allows complilation and calling code has the option to handle the error gracefully at runtime
+pub fn thread_native_id() -> ThreadId {
+    0
+}


### PR DESCRIPTION
Recent changes are tested in Windows. No apparently problems. Excellent!

This PR add a stub for macOS to eliminate the need for runtime platform checks. Instead a specific new exception type is thrown for UnsupportedPlatform while still allowing compilation despite C stdlib differences from Unix standard.

I've assumed that macOS is the exception to platform family "unix". An alternative would be that "linux" is the only platform supporting our threading constructs- not sure, but a reasonable guess which works either way.

Some of the documentation examples needed simplification to avoid "docs are always on Linux, so the old example assertions in docs were not true due to UnsupportedPlatform" when running tests on mac. Thus you likely want to bump the secondary version number for any release.