### PR TITLE
Add Linux SCHED_DEADLINE support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,13 @@ jobs:
         if: matrix.features == ''
         run: cargo build --all-features
 
-      - name: Test all features
-        if: matrix.features == ''
-        run: cargo test --all-features
+      - name: Test all features (macOS)
+        if: matrix.features == '' && runner.os == 'macOS'
+        run: cargo test --all-features -- --skip set_deadline_policy
+
+      - name: Test all features (other)
+        if: matrix.features == '' && runner.os != 'macOS'
+        run: sudo -E $HOME/bin/cargo test --all-features
 
   clippy:
     name: Run clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,12 @@ jobs:
         if: matrix.features == ''
         run: cargo build --all-features
 
-      - name: Test all features (macOS)
-        if: matrix.features == '' && runner.os == 'macOS'
+      - name: Test all features (other)
+        if: matrix.features == '' && runner.os != 'Linux'
         run: cargo test --all-features -- --skip set_deadline_policy
 
-      - name: Test all features (other)
-        if: matrix.features == '' && runner.os != 'macOS'
+      - name: Test all features (Linux)
+        if: matrix.features == '' && runner.os == 'Linux
         run: sudo -E /usr/share/rust/.cargo/bin/cargo test --all-features
 
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: cargo test --all-features -- --skip set_deadline_policy
 
       - name: Test all features (Linux)
-        if: matrix.features == '' && runner.os == 'Linux
+        if: matrix.features == '' && runner.os == 'Linux'
         run: sudo -E /usr/share/rust/.cargo/bin/cargo test --all-features
 
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Test all features (other)
         if: matrix.features == '' && runner.os != 'macOS'
-        run: sudo -E $HOME/bin/cargo test --all-features
+        run: sudo -E /usr/share/rust/.cargo/bin/cargo test --all-features
 
   clippy:
     name: Run clippy

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Cargo.lock
 **/*.swo
 **/*.swp
 .idea/
+Vagrantfile
+.vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 Cargo.lock
 **/*.swo
 **/*.swp
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thread-priority"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Victor Polevoy <fx@thefx.co>"]
 description = "Library for managing threads priority and schedule policies"
 repository = "https://github.com/vityafx/thread-priority"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,11 @@ pub enum ThreadPriority {
     /// a percentage value. The `u32` value is reserved for different
     /// OS'es support.
     Specific(u32),
+    /// Holds scheduling parameters for Deadline scheduling. These are, in order,
+    /// the nanoseconds for runtime, deadline, and period. Please note that the
+    /// kernel enforces runtime <= deadline <= period.
+    #[cfg(target_os = "linux")]
+    Deadline(u64, u64, u64),
     /// Holds a value representing the maximum possible priority.
     /// Should be used with caution, it solely depends on the target
     /// os where the program is going to be running on, how it will

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -174,7 +174,9 @@ impl ThreadPriority {
                 // SCHED_DEADLINE doesn't really have a notion of priority,
                 // so fix min and max time slices to 100ms (the syscall takes ns).
                 #[cfg(target_os = "linux")]
-                ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Deadline) => Ok(100 * 10_u32.pow(6)),
+                ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Deadline) => {
+                    Ok(100 * 10_u32.pow(6))
+                }
                 ThreadSchedulePolicy::Realtime(_) => Ok(1),
                 _ => Ok(0),
             },
@@ -195,7 +197,9 @@ impl ThreadPriority {
                 // SCHED_DEADLINE doesn't really have a notion of priority,
                 // so fix min and max time slices to 100ms (the syscall takes ns).
                 #[cfg(target_os = "linux")]
-                ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Deadline) => Ok(100 * 10_u32.pow(6)),
+                ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Deadline) => {
+                    Ok(100 * 10_u32.pow(6))
+                }
                 ThreadSchedulePolicy::Realtime(_) => Ok(99),
                 _ => Ok(0),
             },
@@ -300,16 +304,14 @@ pub fn set_thread_schedule_policy(
                     tid,
                     &sched_attr as *const _,
                     // we are not setting SCHED_FLAG_RECLAIM nor SCHED_FLAG_DL_OVERRUN
-                    0
+                    0,
                 ) as i32
             }
-            _ => {
-                libc::pthread_setschedparam(
-                    native,
-                    policy.to_posix(),
-                    &params as *const libc::sched_param,
-                )
-            }
+            _ => libc::pthread_setschedparam(
+                native,
+                policy.to_posix(),
+                &params as *const libc::sched_param,
+            ),
         };
         match ret {
             0 => Ok(()),

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -35,6 +35,11 @@ pub struct SchedAttr {
     sched_deadline: u64,
     /// for SCHED_DEADLINE
     sched_period: u64,
+
+    /// Utilization hint
+    sched_util_min: u32,
+    /// Utilization hint
+    sched_util_max: u32,
 }
 
 impl ScheduleParams {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -428,6 +428,9 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn set_deadline_policy() {
+        // allow the identity operation for clarity
+        #![allow(clippy::identity_op)]
+
         assert!(set_thread_priority_and_policy(
             0, // current thread
             ThreadPriority::Deadline(1 * 10_u64.pow(6), 10 * 10_u64.pow(6), 100 * 10_u64.pow(6)),

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -35,11 +35,6 @@ pub struct SchedAttr {
     sched_deadline: u64,
     /// for SCHED_DEADLINE
     sched_period: u64,
-
-    /// Utilization hint
-    sched_util_min: u32,
-    /// Utilization hint
-    sched_util_max: u32,
 }
 
 impl ScheduleParams {


### PR DESCRIPTION
This adds rudimentary support for [`SCHED_DEADLINE`](https://www.kernel.org/doc/Documentation/scheduler/sched-deadline.txt) on Linux systems. It is tested and working on `Linux 5.4.0-84-generic #94-Ubuntu SMP Thu Aug 26 20:27:37 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux`, but I see no reason it wouldn't work as far back as `3.14` when `SCHED_DEADLINE` was introduced.

There's a few ugly bits:
* Since `SCHED_DEADLINE` isn't POSIX, there's a bunch of `#[cfg(target_os = "linux")]` all over the place, a dedicated `linux.rs` might be better. I also noticed some `libc::` dependencies that aren't present on macOS, so I don't know that `unix.rs` is fully POSIX anyway.
* The `ThreadId` passed in is interpreted as a `pid_t` instead of being translated properly (solutions to which are also hacky), since the syscall for deadline scheduling expects a kernel tid (userspace pid).
