### PR TITLE
Add support for SCHED_DEADLINE flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ pub enum ThreadPriority {
     /// the nanoseconds for runtime, deadline, and period. Please note that the
     /// kernel enforces runtime <= deadline <= period.
     #[cfg(target_os = "linux")]
-    Deadline(u64, u64, u64),
+    Deadline(u64, u64, u64, Option<DeadlineFlags>),
     /// Holds a value representing the maximum possible priority.
     /// Should be used with caution, it solely depends on the target
     /// os where the program is going to be running on, how it will

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -110,7 +110,7 @@ pub enum DeadlineFlags {
     ResetOnFork = 0x01,
     /// The thread may reclaim bandwidth that is unused by another realtime thread.
     Reclaim = 0x02,
-    /// Request to be send SIGXCPU when this thread overruns its deadline.
+    /// Request to be sent SIGXCPU when this thread overruns its deadline.
     DeadlineOverrun = 0x04,
 }
 


### PR DESCRIPTION
In reference to #13, this adds support for the three flags supported by SCHED_DEADLINE. 

I don't like that this changes the interface (deadline policy goes from taking 3 `u64` to 3 `u64` and an `Option<DeadlineFlags>`) and am open to alternative suggestions that are backwards-compatible.