### PR TITLE
Change Deadline policy to take Duration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,9 @@
     target_arch = "wasm32",
 ))]
 pub mod unix;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
 #[cfg(any(
     target_os = "linux",
     target_os = "macos",
@@ -221,7 +224,11 @@ variant.
     /// the nanoseconds for runtime, deadline, and period. Please note that the
     /// kernel enforces runtime <= deadline <= period.
     #[cfg(target_os = "linux")]
-    Deadline(u64, u64, u64),
+    Deadline {
+        runtime: Duration,
+        deadline: Duration,
+        period: Duration,
+    },
     /// Holds a value representing the maximum possible priority.
     /// Should be used with caution, it solely depends on the target
     /// os where the program is going to be running on, how it will

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,7 @@ variant.
     /// Holds scheduling parameters for Deadline scheduling. These are, in order,
     /// the nanoseconds for runtime, deadline, and period. Please note that the
     /// kernel enforces runtime <= deadline <= period.
-    /// 
+    ///
     ///   arrival/wakeup                    absolute deadline
     ///        |    start time                    |
     ///        |        |                         |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,10 +223,23 @@ variant.
     /// Holds scheduling parameters for Deadline scheduling. These are, in order,
     /// the nanoseconds for runtime, deadline, and period. Please note that the
     /// kernel enforces runtime <= deadline <= period.
+    /// 
+    ///   arrival/wakeup                    absolute deadline
+    //         |    start time                    |
+    //         |        |                         |
+    //         v        v                         v
+    //    -----x--------xooooooooooooooooo--------x--------x---
+    //                  |<-- Runtime ------->|
+    //         |<----------- Deadline ----------->|
+    //         |<-------------- Period ------------------->|
     #[cfg(target_os = "linux")]
     Deadline {
+        /// Set this to something larger than the average computation time
+        /// or to the worst-case computation time for hard real-time tasks.
         runtime: Duration,
+        /// Set this to the relative deadline.
         deadline: Duration,
+        /// Set this to the period of the task.
         period: Duration,
     },
     /// Holds a value representing the maximum possible priority.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,13 +225,13 @@ variant.
     /// kernel enforces runtime <= deadline <= period.
     /// 
     ///   arrival/wakeup                    absolute deadline
-    //         |    start time                    |
-    //         |        |                         |
-    //         v        v                         v
-    //    -----x--------xooooooooooooooooo--------x--------x---
-    //                  |<-- Runtime ------->|
-    //         |<----------- Deadline ----------->|
-    //         |<-------------- Period ------------------->|
+    ///        |    start time                    |
+    ///        |        |                         |
+    ///        v        v                         v
+    ///   -----x--------xooooooooooooooooo--------x--------x---
+    ///                 |<-- Runtime ------->|
+    ///        |<----------- Deadline ----------->|
+    ///        |<-------------- Period ------------------->|
     #[cfg(target_os = "linux")]
     Deadline {
         /// Set this to something larger than the average computation time

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -284,7 +284,7 @@ impl ThreadPriority {
                 _ => Self::max_value_for_policy(policy).map(|v| v as u32),
             },
             #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
-            ThreadPriority::Deadline(_, _, _) => Err(Error::Priority(
+            ThreadPriority::Deadline { runtime: _, deadline: _, period: _ } => Err(Error::Priority(
                 "Deadline is non-POSIX and cannot be converted.",
             )),
         };
@@ -330,12 +330,13 @@ pub fn set_thread_priority_and_policy(
         // SCHED_DEADLINE policy requires its own syscall
         #[cfg(target_os = "linux")]
         ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Deadline) => {
+            use std::convert::TryInto as _;
             let (runtime, deadline, period) = match priority {
                 ThreadPriority::Deadline { runtime, deadline, period } => (|| Ok((
                     runtime.as_nanos().try_into()?,
                     deadline.as_nanos().try_into()?,
                     period.as_nanos().try_into()?,
-                )))().map_err(|e| Error::Priority("Deadline policy durations don't fit into a `u64`."))?,
+                )))().map_err(|_: std::num::TryFromIntError| Error::Priority("Deadline policy durations don't fit into a `u64`."))?,
                 _ => {
                     return Err(Error::Priority(
                         "Deadline policy given without deadline priority.",

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -331,7 +331,11 @@ pub fn set_thread_priority_and_policy(
         #[cfg(target_os = "linux")]
         ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Deadline) => {
             let (runtime, deadline, period) = match priority {
-                ThreadPriority::Deadline(r, d, p) => (r, d, p),
+                ThreadPriority::Deadline { runtime, deadline, period } => (|| Ok((
+                    runtime.as_nanos().try_into()?,
+                    deadline.as_nanos().try_into()?,
+                    period.as_nanos().try_into()?,
+                )))().map_err(|e| Error::Priority("Deadline policy durations don't fit into a `u64`."))?,
                 _ => {
                     return Err(Error::Priority(
                         "Deadline policy given without deadline priority.",
@@ -343,9 +347,9 @@ pub fn set_thread_priority_and_policy(
                 size: std::mem::size_of::<SchedAttr>() as u32,
                 sched_policy: policy.to_posix() as u32,
 
-                sched_runtime: runtime as u64,
-                sched_deadline: deadline as u64,
-                sched_period: period as u64,
+                sched_runtime: runtime,
+                sched_deadline: deadline,
+                sched_period: period,
 
                 ..Default::default()
             };
@@ -586,10 +590,15 @@ mod tests {
     fn set_deadline_policy() {
         // allow the identity operation for clarity
         #![allow(clippy::identity_op)]
+        use std::time::Duration;
 
         assert!(set_thread_priority_and_policy(
             0, // current thread
-            ThreadPriority::Deadline(1 * 10_u64.pow(6), 10 * 10_u64.pow(6), 100 * 10_u64.pow(6)),
+            ThreadPriority::Deadline {
+                runtime: Duration::from_millis(1),
+                deadline: Duration::from_millis(10),
+                period: Duration::from_millis(100),
+            },
             ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Deadline)
         )
         .is_ok());


### PR DESCRIPTION
This PR changes the `ThreadPolicy::Deadline` variant to use `Duration` for `runtime`, `deadline`, and `period` instead of raw `u64` nanoseconds.