### PR TITLE
Fix definition of `ThreadPriorityValue::MAX`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub enum Error {
 pub struct ThreadPriorityValue(u8);
 impl ThreadPriorityValue {
     /// The maximum value for a thread priority.
-    pub const MAX: u8 = 100;
+    pub const MAX: u8 = 99;
     /// The minimum value for a thread priority.
     pub const MIN: u8 = 0;
 }
@@ -178,7 +178,7 @@ impl std::convert::TryFrom<u8> for ThreadPriorityValue {
     type Error = &'static str;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        if (Self::MIN..Self::MAX).contains(&value) {
+        if (Self::MIN..=Self::MAX).contains(&value) {
             Ok(Self(value))
         } else {
             Err("The value is not in the range of [0;99]")


### PR DESCRIPTION
100 is out of range, so `ThreadPriorityValue::MAX` was defined as an invalid priority value. Set it to 99 instead, and adjust the range check.