### PR TITLE
add support for iOS target, use `pthread_setschedparam` on macOS target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rstest = "0.13"
 log = "0.4"
 cfg-if = "1"
 
-[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 libc = ">=0.2.123"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@
 #[cfg(any(
     target_os = "linux",
     target_os = "macos",
+    target_os = "ios",
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "openbsd",
@@ -104,6 +105,7 @@ use std::time::Duration;
 #[cfg(any(
     target_os = "linux",
     target_os = "macos",
+    target_os = "ios",
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "openbsd",

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -29,6 +29,7 @@ fn get_and_set_priority_with_normal_policies(
 // In macOS it is allowed to specify number as a SCHED_OTHER policy priority.
 #[cfg(any(
     target_os = "macos",
+    target_os = "ios",
     target_os = "openbsd",
     target_os = "freebsd",
     target_os = "netbsd"
@@ -90,6 +91,7 @@ fn set_priority_with_normal_policy_but_with_invalid_value(#[case] policy: Thread
 
 #[cfg(any(
     target_os = "macos",
+    target_os = "ios",
     target_os = "openbsd",
     target_os = "freebsd",
     target_os = "netbsd"


### PR DESCRIPTION
on apple targets, only `pthread_setschedparam` is allowed to upgrade threads to a higher priority. this PR change the implementation of `set_thread_priority_and_policy_deadline` on macOS and iOS targets to use `pthread_setschedparam` only.

Ref: 

- https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/pthread_setschedparam.3.html#//apple_ref/doc/man/3/pthread_setschedparam
- https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html#//apple_ref/doc/uid/10000057i-CH15-SW12
- https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/pthread_setschedparam.3.html#//apple_ref/doc/man/3/pthread_setschedparam