### PR TITLE
[FEAT] add scoped thread support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rstest = "0.13"
 [dependencies]
 log = "0.4"
 cfg-if = "1"
+rustversion = "1.0.11"
 
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 libc = ">=0.2.123"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,6 +486,8 @@ impl ThreadBuilder {
     /// [`std::io::Result`] to its [`std::thread::ScopedJoinHandle`].
     ///
     /// See [`std::thread::Builder::spawn_scoped`]
+    #[rustversion::since(1.63)]
+    #[cfg(unix)]
     pub fn spawn_scoped<'scope, 'env, F, T>(
         mut self,
         scope: &'scope std::thread::Scope<'scope, 'env>,
@@ -518,6 +520,7 @@ impl ThreadBuilder {
     /// [`std::io::Result`] to its [`std::thread::ScopedJoinHandle`].
     ///
     /// See [`std::thread::Builder::spawn_scoped`]
+    #[rustversion::since(1.63)]
     #[cfg(windows)]
     pub fn spawn_scoped<'scope, 'env, F, T>(mut self, scope: &'scope std::thread::Scope<'scope, 'env>, f: F) -> std::io::Result<std::thread::ScopedJoinHandle<'scope, T>>
     where


### PR DESCRIPTION
Implement the feature proposed here. https://github.com/vityafx/thread-priority/issues/27

This is mostly a "copy and modification" of the `spawn` function.

Potential problems with this modification: 
- [ ] Test coverage: the old `spawn` function does not have any test, so the new `spawn_scoped` is also not covered yet. 
- [ ] Duplicated code: `spawn` and `spawn_scoped` share similar code, but I haven't found a clean solution to extract the common part

TODOs:
- [ ] `ThreadBuilder::spawn_scoped_careless`
- [ ] `ThreadBuilderExt::spawn_scoped_with_priority`