### PR TITLE
Update windows dependency to 0.62

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ libc = ">=0.2.161"
 
 [target.'cfg(windows)'.dependencies]
 libc = ">=0.2.123"
-windows = { version = "0.61", features = [
+windows = { version = ">=0.61", features = [
     "Win32",
     "Win32_System",
     "Win32_System_Threading",


### PR DESCRIPTION
## Why

In my project, I've other dependencies that depend on 0.62, `thread-priority` depends on 0.61, this results in duplicate `windows` deps, which increases the size of my binary, and my compilation time.

## Testing

I tested the change on my Windows machine running `cargo test`, all tests pass.

## Breaking

Depending on whether this crate re-exports or exposes types from `windows`, this may be a breaking change.

----

Cheers :)